### PR TITLE
feat(config): add payload length in the config struct (default 64 bytes)

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,13 +2,17 @@ package nflog
 
 type Config struct {
 	Groups []uint16
+    PayloadLength uint32
 	Return struct {
 		Errors bool
 	}
 }
 
 func NewConfig() *Config {
-	return &Config{}
+    cfg := &Config{}
+    cfg.PayloadLength = 0x40000000
+
+    return cfg
 }
 
 func (c Config) Validate() error {

--- a/nflog.go
+++ b/nflog.go
@@ -59,7 +59,7 @@ func New(conf *Config) (*NFLog, error) {
 		}
 
 		// Set CopyMeta only
-		err = n.sendNFConfigMode(g, 0x40000000)
+		err = n.sendNFConfigMode(g, conf.PayloadLength)
 		if err != nil {
 			syscall.Close(n.fd)
 			return nil, err


### PR DESCRIPTION
Why not letting user customize the payload length?